### PR TITLE
refactor: docker-compose redis port, bookAffiliation similarityToken

### DIFF
--- a/bookmaru-application/src/main/kotlin/plain/bookmaru/domain/inventory/model/BookAffiliation.kt
+++ b/bookmaru-application/src/main/kotlin/plain/bookmaru/domain/inventory/model/BookAffiliation.kt
@@ -11,5 +11,5 @@ class BookAffiliation(
     val rentalCount: Int,
     val reservationCount: Int,
     val likeCount: Int,
-    val similarityToken: String
+    val similarityToken: String?
 )

--- a/bookmaru-infrastructure/src/main/kotlin/plain/bookmaru/domain/inventory/persistent/entity/BookAffiliationEntity.kt
+++ b/bookmaru-infrastructure/src/main/kotlin/plain/bookmaru/domain/inventory/persistent/entity/BookAffiliationEntity.kt
@@ -38,7 +38,8 @@ class BookAffiliationEntity(
     @JoinColumn(name = "affiliation_id", nullable = false)
     val affiliationEntity: AffiliationEntity,
 
-    val similarityToken: String
+    @Column(name = "similarity_token", columnDefinition = "tsvector", insertable = false, updatable = false)
+    val similarityToken: String?
 
 ) : BaseEntity() {
     @Id

--- a/bookmaru-infrastructure/src/main/resources/application.yml
+++ b/bookmaru-infrastructure/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
   data:
     redis:
       host: ${REDIS_HOST}
-      port: 6379
+      port: 6381
       password: ${REDIS_PASSWORD}
 
       db-index:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     image: redis:7-alpine
     restart: always
     ports:
-      - "6379:6379"
+      - "6381:6379"
 
   elasticsearch:
     build: ./elasticsearch


### PR DESCRIPTION
- docker-compose redis port 정보 6381로 수정
- similarityToken 정보 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **설정 변경**
  * Redis 외부 포트가 6379에서 6381로 변경되었습니다.

* **기술 개선**
  * 도메인 모델에서 특정 토큰 값이 선택적(널 허용)으로 변경되어 일부 레코드에서 값이 비어 있어도 정상 처리됩니다.
  * 해당 토큰은 더 이상 애플리케이션 내부에서 직접 갱신되지 않으며, 외부에서 관리되는 값으로 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->